### PR TITLE
Add naive sprite rendering

### DIFF
--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,5 +1,5 @@
 use instructions::op_length;
-use mmu::{IE_REG, IF_REG, MMU};
+use mmu::{IE_REG, IF_REG, LCDC_REG, MMU};
 use std::fs::File;
 use std::io::Write;
 use timer::Timer;
@@ -40,6 +40,33 @@ pub fn print_stack(mmu: &MMU, sp: u16) {
             a -= 2;
         }
         println!();
+    }
+}
+
+pub fn print_sprite(mmu: &MMU, i: usize) {
+    let offset = 0xFE00 + (i * 4) as u16;
+    let x = mmu.direct_read(offset + 1);
+    let y = mmu.direct_read(offset);
+    if x != 0 && y != 0 {
+        println!(" - Sprite {} @ 0x{:04X}: X={}, Y={}, Pattern={}, Flags=0x{:02X}",
+            i,
+            offset,
+            x,
+            y,
+            mmu.direct_read(offset + 2),
+            mmu.direct_read(offset + 3)
+        );
+    }
+}
+
+pub fn print_sprites(mmu: &MMU) {
+    let lcdc = mmu.direct_read(LCDC_REG);
+
+    println!("Sprites are: {}", if lcdc & 2 == 0 { "disabled" } else { "enabled" });
+    println!("Sprite size: {}", if lcdc & 4 == 0 { "8x8"} else { "8x16" });
+
+    for i in 0..40 {
+        print_sprite(mmu, i);
     }
 }
 

--- a/src/dma.rs
+++ b/src/dma.rs
@@ -13,7 +13,6 @@ pub struct DMA {
     pub start_request_delay: Option<u16>,
     pub start_address: Option<u16>,
     pub step: u16,
-    pub oam: [u8; 0xA0],
 
     // This is to handle a quirk: the DMA address (0xFF46) should
     // always return the last written value on read operations,
@@ -28,27 +27,12 @@ impl DMA {
             start_request_delay: None,
             start_address: None,
             step: 0,
-            oam: [0; 0xA0],
             last_write_dma_reg: 0xFF,
         }
     }
 
     pub fn is_active(&self) -> bool {
         self.start_address.is_some()
-    }
-
-    pub fn read(&self, address: u16) -> u8 {
-        if self.is_active() {
-            return 0xFF;
-        } else {
-            return self.oam[address as usize];
-        }
-    }
-
-    pub fn write(&mut self, address: u16, value: u8) {
-        if !self.is_active() {
-            self.oam[address as usize] = value;
-        }
     }
 
     pub fn start(&mut self, start: u8) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ mod timer;
 mod ui;
 mod buttons;
 
-use debug::{format_mnemonic, print_listing, print_registers};
+use debug::{format_mnemonic, print_listing, print_registers, print_sprites};
 use emu::Emu;
 use lcd::{LCD, SCREEN_HEIGHT, SCREEN_WIDTH};
 use buttons::ButtonType;
@@ -320,6 +320,9 @@ fn main() -> Result<(), String> {
                                 Err(_) => println!("Not a valid address"),
                             };
                         }
+                    }
+                    "sprites" => {
+                        print_sprites(&emu.mmu);
                     }
                     "" => {}
                     _ => {

--- a/src/mmu.rs
+++ b/src/mmu.rs
@@ -163,7 +163,7 @@ impl MMU {
                     } else {
                         self.ram[(offset + idx - 0xE000) as usize]
                     };
-                    self.dma.oam[idx as usize] = b;
+                    self.lcd.oam[idx as usize] = b;
                 }
                 self.dma.update();
             }
@@ -221,7 +221,7 @@ impl MMU {
                 if self.dma.is_active() {
                     0xFF
                 } else {
-                    self.dma.read(addr - 0xFE00)
+                    self.lcd.oam[addr as usize - 0xFE00]
                 }
             }
 
@@ -295,7 +295,11 @@ impl MMU {
             0xC000...0xCFFF => self.ram[(addr - 0xC000) as usize] = value,
             0xD000...0xDFFF => self.ram[(addr - 0xC000) as usize] = value,
             0xE000...0xFDFF => self.ram[(addr - 0xE000) as usize] = value,
-            0xFE00...0xFE9F => self.dma.write(addr - 0xFE00, value),
+            0xFE00...0xFE9F => {
+                if !self.dma.is_active() {
+                    self.lcd.oam[addr as usize - 0xFE00] = value
+                }
+            },
 
             0xFEA0...0xFEFF => {},
             0xFF10...0xFF26 => {},


### PR DESCRIPTION
This commit adds a very naive and inefficient sprite rendering.
After rending a scanline of background, all the sprites that
belongs to that line are rendered.

With this change in place Tetris can finally be played
with full graphics support!

- Adds debug command 'sprites' that prints all active sprites
- Moves OAM memory from the DMA class to LCD
- The functionality of DMA.read and DMA.write are now implemented in MMU.