### PR TITLE
Add simple audio mixer and fix frequency bug for square wave

### DIFF
--- a/src/apu/apu.rs
+++ b/src/apu/apu.rs
@@ -122,7 +122,40 @@ impl AudioProcessingUnit {
         let ch3_output = self.ch3.update_4t(hz256);
         let ch4_output = self.ch4.update_4t(hz64, hz256);
 
-        let sample = (ch1_output + ch2_output + ch3_output + ch4_output) as f32;
+        // Mixer
+        let mut left: f32 = 0.0;
+        if self.nr51 & 128 != 0 {
+            left += ch4_output;
+        }
+        if self.nr51 & 64 != 0 {
+            left += ch3_output;
+        }
+        if self.nr51 & 32 != 0 {
+            left += ch2_output;
+        }
+        if self.nr51 & 16 != 0 {
+            left += ch1_output;
+        }
+
+        let mut right: f32 = 0.0;
+        if self.nr51 & 8 != 0 {
+            right += ch4_output;
+        }
+        if self.nr51 & 4 != 0 {
+            right += ch3_output;
+        }
+        if self.nr51 & 2 != 0 {
+            right += ch2_output;
+        }
+        if self.nr51 & 1 != 0 {
+            right += ch1_output;
+        }
+
+        // FIXME: for now, left and right channel
+        // is joined to a mono channel, and the volume
+        // is lowered to 30%.
+        let sample = (left + right) / 2.0;
+        let sample = sample * 0.3;
 
         if let Some(ref mut rec) = self.recorder {
             rec.gen1(ch1_output as f32);

--- a/src/apu/mod.rs
+++ b/src/apu/mod.rs
@@ -16,6 +16,7 @@
 // - After the sound hardware is powered on, frame sequencer should be
 //   reset so next step is step 0.
 // - Remove duplicated envelope code
+// - Volume for left and right channel (NR50) is not handled
 
 pub mod apu;
 pub mod dac;

--- a/src/apu/square_gen.rs
+++ b/src/apu/square_gen.rs
@@ -43,7 +43,7 @@ use crate::mmu::{
 //
 pub struct SquareWaveSoundGenerator {
     // Frequency. 10 bits. Bit 7..0 in NR13 + bit 9..8 in NR14.
-    frequency: u16,
+    pub frequency: u16,
 
     // Internal register. When this counter reaches zero,
     // it is reset to the frequency value (NR13, NR14) and
@@ -203,11 +203,11 @@ impl SquareWaveSoundGenerator {
                 self.envelope_periods_initial = value & 0b111;
             }
             NR13_REG | NR23_REG => {
-                self.frequency = (self.frequency & 0b11_0000_0000) | value as u16
+                self.frequency = (self.frequency & 0b111_0000_0000) | value as u16
             }
             NR14_REG | NR24_REG => {
                 self.frequency =
-                    (self.frequency & 0b00_1111_1111) | (((value & 0b111) as u16) << 8);
+                    (self.frequency & 0b000_1111_1111) | (((value & 0b111) as u16) << 8);
 
                 if self
                     .length_counter
@@ -234,8 +234,6 @@ impl SquareWaveSoundGenerator {
         if let Some(ref mut sweep) = self.sweep {
             sweep.trigger(&mut self.enabled, &mut self.frequency);
         }
-
-        // FIXME: add sweep trigger handling
 
         // If DAC is not powered, immediately disable the channel again
         if !self.dac.powered_on {

--- a/src/ui/audio_window.rs
+++ b/src/ui/audio_window.rs
@@ -53,6 +53,7 @@ pub fn render_audio_window(ctx: &CtxRef, emu: &mut Emu) {
         ui.heading("Channel 1");
         ui.label(format!("Enabled: {}", emu.mmu.apu.s1.enabled));
         ui.label(format!("Envelope: {}", emu.mmu.apu.s1.envelope));
+        ui.label(format!("Frequency: {}", emu.mmu.apu.s1.frequency));
 
         ui.heading("Channel 2");
         ui.label(format!("Enabled: {}", emu.mmu.apu.s2.enabled));


### PR DESCRIPTION
The frequency bug caused some bass notes in Pokemon Red.
﻿
